### PR TITLE
CNSL-12 Enable GET API keys endpoint

### DIFF
--- a/auth/api/http/keys/endpoint_test.go
+++ b/auth/api/http/keys/endpoint_test.go
@@ -237,6 +237,139 @@ func TestRetrieve(t *testing.T) {
 	}
 }
 
+func TestRetrieveAll(t *testing.T) {
+	svc := newService()
+	_, loginSecret, err := svc.Issue(context.Background(), "", auth.Key{Type: auth.UserKey, IssuedAt: time.Now(), IssuerID: id, Subject: email})
+	assert.Nil(t, err, fmt.Sprintf("Issuing login key expected to succeed: %s", err))
+
+	n := uint64(100)
+	var data []auth.Key
+	for i := uint64(0); i < n; i++ {
+		key := auth.Key{Type: auth.APIKey, IssuedAt: time.Now(), IssuerID: id, Subject: fmt.Sprintf("user_%d@example.com", i)}
+
+		k, _, err := svc.Issue(context.Background(), loginSecret, key)
+		assert.Nil(t, err, fmt.Sprintf("Issuing login key expected to succeed: %s", err))
+		k.ExpiresAt = time.Time{}
+		data = append(data, k)
+	}
+
+	ts := newServer(svc)
+	defer ts.Close()
+	client := ts.Client()
+
+	cases := []struct {
+		desc   string
+		url    string
+		auth   string
+		status int
+		res    []auth.Key
+	}{
+		{
+			desc:   "get a list of keys",
+			auth:   loginSecret,
+			status: http.StatusOK,
+			url:    fmt.Sprintf("?offset=%d&limit=%d", 0, 5),
+			res:    data[0:5],
+		},
+		{
+			desc:   "get a list of keys with invalid token",
+			auth:   "wrongValue",
+			status: http.StatusUnauthorized,
+			url:    fmt.Sprintf("?offset=%d&limit=%d", 0, 1),
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys with empty token",
+			auth:   "",
+			status: http.StatusUnauthorized,
+			url:    fmt.Sprintf("?offset=%d&limit=%d", 0, 1),
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys with negative offset",
+			auth:   loginSecret,
+			status: http.StatusBadRequest,
+			url:    fmt.Sprintf("?offset=%d&limit=%d", -1, 5),
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys with negative limit",
+			auth:   loginSecret,
+			status: http.StatusBadRequest,
+			url:    fmt.Sprintf("?offset=%d&limit=%d", 1, -5),
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys with zero limit and offset 1",
+			auth:   loginSecret,
+			status: http.StatusBadRequest,
+			url:    fmt.Sprintf("?offset=%d&limit=%d", 1, 0),
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys without offset",
+			auth:   loginSecret,
+			status: http.StatusOK,
+			url:    fmt.Sprintf("?limit=%d", 5),
+			res:    data[0:5],
+		},
+		{
+			desc:   "get a list of keys without limit",
+			auth:   loginSecret,
+			status: http.StatusOK,
+			url:    fmt.Sprintf("?offset=%d", 1),
+			res:    data[1:11],
+		},
+		{
+			desc:   "get a list of keys with redundant query params",
+			auth:   loginSecret,
+			status: http.StatusOK,
+			url:    fmt.Sprintf("?offset=%d&limit=%d&value=something", 0, 5),
+			res:    data[0:5],
+		},
+		{
+			desc:   "get a list of keys with default URL",
+			auth:   loginSecret,
+			status: http.StatusOK,
+			url:    "",
+			res:    data[0:10],
+		},
+		{
+			desc:   "get a list of keys with invalid number of params",
+			auth:   loginSecret,
+			status: http.StatusBadRequest,
+			url:    "?offset=4&limit=4&limit=5&offset=5",
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys with invalid offset",
+			auth:   loginSecret,
+			status: http.StatusBadRequest,
+			url:    "?offset=e&limit=5",
+			res:    nil,
+		},
+		{
+			desc:   "get a list of keys with invalid limit",
+			auth:   loginSecret,
+			status: http.StatusBadRequest,
+			url:    "?offset=5&limit=e",
+			res:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		req := testRequest{
+			client: client,
+			method: http.MethodGet,
+			url:    fmt.Sprintf("%s/keys%s", ts.URL, tc.url),
+			token:  tc.auth,
+		}
+		res, err := req.make()
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
+		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status code %d got %d", tc.desc, tc.status, res.StatusCode))
+	}
+}
+
 func TestRevoke(t *testing.T) {
 	svc := newService()
 	_, loginSecret, err := svc.Issue(context.Background(), "", auth.Key{Type: auth.UserKey, IssuedAt: time.Now(), IssuerID: id, Subject: email})

--- a/auth/api/http/keys/requests.go
+++ b/auth/api/http/keys/requests.go
@@ -37,3 +37,23 @@ func (req keyReq) validate() error {
 	}
 	return nil
 }
+
+type listKeysReq struct {
+	token   string
+	subject string
+	keyType uint32
+	offset  uint64
+	limit   uint64
+}
+
+func (req listKeysReq) validate() error {
+	if req.token == "" {
+		return auth.ErrBearerToken
+	}
+
+	if req.limit < 1 {
+		return auth.ErrLimitSize
+	}
+
+	return nil
+}

--- a/auth/api/http/keys/responses.go
+++ b/auth/api/http/keys/responses.go
@@ -66,6 +66,17 @@ func (res revokeKeyRes) Headers() map[string]string {
 	return map[string]string{}
 }
 
+type keyPageRes struct {
+	pageRes
+	Keys []retrieveKeyRes `json:"keys"`
+}
+
+type pageRes struct {
+	Limit  uint64 `json:"limit,omitempty"`
+	Offset uint64 `json:"offset,omitempty"`
+	Total  uint64 `json:"total"`
+}
+
 func (res revokeKeyRes) Empty() bool {
 	return true
 }

--- a/auth/api/http/keys/transport.go
+++ b/auth/api/http/keys/transport.go
@@ -15,11 +15,21 @@ import (
 	"github.com/go-zoo/bone"
 	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/auth"
+	"github.com/mainflux/mainflux/internal/httputil"
 	"github.com/mainflux/mainflux/pkg/errors"
 	"github.com/opentracing/opentracing-go"
 )
 
-const contentType = "application/json"
+const (
+	contentType = "application/json"
+	offsetKey   = "offset"
+	limitKey    = "limit"
+	subjectKey  = "subject"
+	typeKey     = "type"
+	defOffset   = 0
+	defLimit    = 10
+	defType     = 2
+)
 
 var errUnsupportedContentType = errors.New("unsupported content type")
 
@@ -30,6 +40,13 @@ func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer) *bo
 	mux.Post("/keys", kithttp.NewServer(
 		kitot.TraceServer(tracer, "issue")(issueEndpoint(svc)),
 		decodeIssue,
+		encodeResponse,
+		opts...,
+	))
+
+	mux.Get("/keys", kithttp.NewServer(
+		kitot.TraceServer(tracer, "issue")(retrieveKeysEndpoint(svc)),
+		decodeListKeysRequest,
 		encodeResponse,
 		opts...,
 	))
@@ -73,6 +90,37 @@ func decodeKeyReq(_ context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
+func decodeListKeysRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	s, err := httputil.ReadStringQuery(r, subjectKey, "")
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := httputil.ReadUintQuery(r, typeKey, defType)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := httputil.ReadUintQuery(r, offsetKey, defOffset)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := httputil.ReadUintQuery(r, limitKey, defLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	req := listKeysReq{
+		token:   httputil.ExtractBearerToken(r),
+		subject: s,
+		keyType: uint32(t),
+		offset:  o,
+		limit:   l,
+	}
+	return req, nil
+}
+
 func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", contentType)
 
@@ -99,6 +147,14 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusForbidden)
 	case errors.Contains(err, auth.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)
+	case errors.Contains(err, errors.ErrInvalidQueryParams),
+		errors.Contains(err, errors.ErrMalformedEntity),
+		err == auth.ErrMissingID,
+		err == auth.ErrBearerKey,
+		err == auth.ErrLimitSize,
+		err == auth.ErrOffsetSize,
+		err == auth.ErrInvalidIDFormat:
+		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, auth.ErrConflict):
 		w.WriteHeader(http.StatusConflict)
 	case errors.Contains(err, io.EOF):

--- a/auth/api/http/keys/transport.go
+++ b/auth/api/http/keys/transport.go
@@ -28,7 +28,7 @@ const (
 	typeKey     = "type"
 	defOffset   = 0
 	defLimit    = 10
-	defType     = 2
+	defType     = 3
 )
 
 var errUnsupportedContentType = errors.New("unsupported content type")

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -70,6 +70,19 @@ func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) 
 	return lm.svc.RetrieveKey(ctx, token, id)
 }
 
+func (lm *loggingMiddleware) RetrieveKeys(ctx context.Context, token string, pm auth.PageMetadata) (kp auth.KeyPage, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method retrieve for token %s took %s to complete", token, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.RetrieveKeys(ctx, token, pm)
+}
+
 func (lm *loggingMiddleware) Identify(ctx context.Context, key string) (id auth.Identity, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method identify took %s to complete", time.Since(begin))

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -55,6 +55,15 @@ func (ms *metricsMiddleware) RetrieveKey(ctx context.Context, token, id string) 
 	return ms.svc.RetrieveKey(ctx, token, id)
 }
 
+func (ms *metricsMiddleware) RetrieveKeys(ctx context.Context, token string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "retrieve_keys").Add(1)
+		ms.latency.With("method", "retrieve_keys").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.RetrieveKeys(ctx, token, pm)
+}
+
 func (ms *metricsMiddleware) Identify(ctx context.Context, token string) (auth.Identity, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "identify").Add(1)

--- a/auth/groups.go
+++ b/auth/groups.go
@@ -92,7 +92,8 @@ type PageMetadata struct {
 	Size     uint64
 	Level    uint64
 	Name     string
-	Type     string
+	Type     uint32
+	Subject  string
 	Metadata GroupMetadata
 }
 

--- a/auth/keys.go
+++ b/auth/keys.go
@@ -42,6 +42,12 @@ type Key struct {
 	ExpiresAt time.Time
 }
 
+// KeyPage contains a page of keys.
+type KeyPage struct {
+	PageMetadata
+	Keys []Key
+}
+
 // Identity contains ID and Email.
 type Identity struct {
 	ID    string
@@ -62,8 +68,11 @@ type KeyRepository interface {
 	// operation failure
 	Save(context.Context, Key) (string, error)
 
-	// Retrieve retrieves Key by its unique identifier.
-	Retrieve(context.Context, string, string) (Key, error)
+	// RetrieveByID retrieves Key by its unique identifier.
+	RetrieveByID(context.Context, string, string) (Key, error)
+
+	// RetrieveAll retrieves all keys for given user ID.
+	RetrieveAll(context.Context, string, PageMetadata) (KeyPage, error)
 
 	// Remove removes Key with provided ID.
 	Remove(context.Context, string, string) error

--- a/auth/mocks/keys.go
+++ b/auth/mocks/keys.go
@@ -35,7 +35,7 @@ func (krm *keyRepositoryMock) Save(ctx context.Context, key auth.Key) (string, e
 	krm.keys[key.ID] = key
 	return key.ID, nil
 }
-func (krm *keyRepositoryMock) Retrieve(ctx context.Context, issuerID, id string) (auth.Key, error) {
+func (krm *keyRepositoryMock) RetrieveByID(ctx context.Context, issuerID, id string) (auth.Key, error) {
 	krm.mu.Lock()
 	defer krm.mu.Unlock()
 
@@ -44,6 +44,26 @@ func (krm *keyRepositoryMock) Retrieve(ctx context.Context, issuerID, id string)
 	}
 
 	return auth.Key{}, auth.ErrNotFound
+}
+func (krm *keyRepositoryMock) RetrieveAll(ctx context.Context, issuerID string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	krm.mu.Lock()
+	defer krm.mu.Unlock()
+
+	kp := auth.KeyPage{}
+	i := uint64(0)
+
+	for _, k := range krm.keys {
+		if i >= pm.Offset && i < (pm.Limit+pm.Offset) {
+			kp.Keys = append(kp.Keys, k)
+		}
+		i++
+	}
+
+	kp.Offset = pm.Offset
+	kp.Limit = pm.Limit
+	kp.Total = uint64(i)
+
+	return kp, nil
 }
 func (krm *keyRepositoryMock) Remove(ctx context.Context, issuerID, id string) error {
 	krm.mu.Lock()

--- a/auth/postgres/key.go
+++ b/auth/postgres/key.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -14,6 +16,7 @@ var (
 	errSave     = errors.New("failed to save key in database")
 	errRetrieve = errors.New("failed to retrieve key from database")
 	errDelete   = errors.New("failed to delete key from database")
+	errView     = errors.New("View entity failed")
 )
 var _ auth.KeyRepository = (*repo)(nil)
 
@@ -53,7 +56,7 @@ func (kr repo) Save(ctx context.Context, key auth.Key) (string, error) {
 	return dbKey.ID, nil
 }
 
-func (kr repo) Retrieve(ctx context.Context, issuerID, id string) (auth.Key, error) {
+func (kr repo) RetrieveByID(ctx context.Context, issuerID, id string) (auth.Key, error) {
 	q := `SELECT id, type, issuer_id, subject, issued_at, expires_at FROM keys WHERE issuer_id = $1 AND id = $2`
 	key := dbKey{}
 	if err := kr.db.QueryRowxContext(ctx, q, issuerID, id).StructScan(&key); err != nil {
@@ -66,6 +69,62 @@ func (kr repo) Retrieve(ctx context.Context, issuerID, id string) (auth.Key, err
 	}
 
 	return toKey(key), nil
+}
+
+func (kr repo) RetrieveAll(ctx context.Context, issuerID string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	var query []string
+	var emq string
+	query = append(query, fmt.Sprintf("issuer_id = '%s'", issuerID))
+	if pm.Type != 0 {
+		query = append(query, fmt.Sprintf("type = '%d'", pm.Type))
+	}
+	if pm.Subject != "" {
+		query = append(query, fmt.Sprintf("subject = '%s'", pm.Subject))
+	}
+	if len(query) > 0 {
+		emq = fmt.Sprintf(" WHERE %s", strings.Join(query, " AND "))
+	}
+
+	q := fmt.Sprintf(`SELECT id, type, issuer_id, subject, issued_at, expires_at FROM keys %s ORDER BY issued_at LIMIT :limit OFFSET :offset;`, emq)
+	params := map[string]interface{}{
+		"limit":  pm.Limit,
+		"offset": pm.Offset,
+	}
+
+	rows, err := kr.db.NamedQueryContext(ctx, q, params)
+	if err != nil {
+		return auth.KeyPage{}, errors.Wrap(errView, err)
+	}
+	defer rows.Close()
+
+	var items []auth.Key
+	for rows.Next() {
+		dbkey := dbKey{}
+		if err := rows.StructScan(&dbkey); err != nil {
+			return auth.KeyPage{}, errors.Wrap(errView, err)
+		}
+
+		key := toKey(dbkey)
+		items = append(items, key)
+	}
+
+	cq := fmt.Sprintf(`SELECT COUNT(*) FROM keys %s;`, emq)
+
+	total, err := total(ctx, kr.db, cq, params)
+	if err != nil {
+		return auth.KeyPage{}, errors.Wrap(errView, err)
+	}
+
+	page := auth.KeyPage{
+		Keys: items,
+		PageMetadata: auth.PageMetadata{
+			Total:  total,
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+		},
+	}
+
+	return page, nil
 }
 
 func (kr repo) Remove(ctx context.Context, issuerID, id string) error {

--- a/auth/postgres/key_test.go
+++ b/auth/postgres/key_test.go
@@ -69,7 +69,7 @@ func TestKeySave(t *testing.T) {
 	}
 }
 
-func TestKeyRetrieve(t *testing.T) {
+func TestKeyRetrieveById(t *testing.T) {
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.New(dbMiddleware)
 
@@ -112,8 +112,131 @@ func TestKeyRetrieve(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, err := repo.Retrieve(context.Background(), tc.owner, tc.id)
+		_, err := repo.RetrieveByID(context.Background(), tc.owner, tc.id)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestKeyRetrieveAll(t *testing.T) {
+	dbMiddleware := postgres.NewDatabase(db)
+	repo := postgres.New(dbMiddleware)
+
+	issuerID1, err := idProvider.ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	issuerID2, err := idProvider.ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	n := uint64(100)
+	for i := uint64(0); i < n; i++ {
+		id, err := idProvider.ID()
+		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+		key := auth.Key{
+			Subject:   fmt.Sprintf("key-%d@email.com", i),
+			IssuedAt:  time.Now(),
+			ExpiresAt: expTime,
+			ID:        id,
+			IssuerID:  issuerID1,
+			Type:      auth.UserKey,
+		}
+		if i%10 == 0 {
+			key.Type = auth.APIKey
+		}
+		if i == n-1 {
+			key.IssuerID = issuerID2
+		}
+		_, err = repo.Save(context.Background(), key)
+		assert.Nil(t, err, fmt.Sprintf("Storing Key expected to succeed: %s", err))
+	}
+
+	cases := map[string]struct {
+		owner        string
+		pageMetadata auth.PageMetadata
+		size         uint64
+	}{
+		"retrieve all keys": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  n,
+			},
+			size: n - 1,
+		},
+		"retrieve all keys with different issuer ID": {
+			owner: issuerID2,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  n,
+			},
+			size: 1,
+		},
+		"retrieve subset of keys with existing owner": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: n/2 - 1,
+				Limit:  n,
+				Total:  n,
+			},
+			size: n / 2,
+		},
+		"retrieve keys with existing subject": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset:  0,
+				Limit:   n,
+				Subject: "key-10@email.com",
+			},
+			size: 1,
+		},
+		"retrieve keys with non-existing subject": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset:  0,
+				Limit:   n,
+				Subject: "wrong",
+				Total:   0,
+			},
+			size: 0,
+		},
+		"retrieve keys with existing type": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Type:   auth.APIKey,
+			},
+			size: 10,
+		},
+		"retrieve keys with non-existing type": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  0,
+				Type:   uint32(9),
+			},
+			size: 0,
+		},
+		"retrieve all keys with existing subject and type": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset:  0,
+				Limit:   n,
+				Subject: "key-10@email.com",
+				Type:    auth.APIKey,
+			},
+			size: 1,
+		},
+	}
+
+	for desc, tc := range cases {
+		page, err := repo.RetrieveAll(context.Background(), tc.owner, tc.pageMetadata)
+		size := uint64(len(page.Keys))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
+		// assert.Equal(t, tc.pageMetadata.Total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.pageMetadata.Total, page.Total))
+		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %d\n", desc, err))
 	}
 }
 

--- a/auth/service.go
+++ b/auth/service.go
@@ -50,6 +50,26 @@ var (
 	// ErrFailedToRetrieveChildren failed to retrieve groups.
 	ErrFailedToRetrieveChildren = errors.New("failed to retrieve all groups")
 
+	// These error codes are taken from the master branch located under
+	// the ./internal/apiutil/errors.go file, which is not present here
+	// ErrBearerToken indicates missing or invalid bearer user token.
+	ErrBearerToken = errors.New("missing or invalid bearer user token")
+
+	// ErrBearerKey indicates missing or invalid bearer entity key.
+	ErrBearerKey = errors.New("missing or invalid bearer entity key")
+
+	// ErrLimitSize limit value is invalid.
+	ErrLimitSize = errors.New("invalid limit value")
+
+	// ErrMissingID indicates missing entity ID.
+	ErrMissingID = errors.New("missing entity id")
+
+	// ErrOffsetSize indicates an invalid offset.
+	ErrOffsetSize = errors.New("invalid offset size")
+
+	// ErrInvalidIDFormat indicates an invalid ID format.
+	ErrInvalidIDFormat = errors.New("invalid id format provided")
+
 	errIssueUser = errors.New("failed to issue new user key")
 	errIssueTmp  = errors.New("failed to issue new temporary key")
 	errRevoke    = errors.New("failed to remove key")
@@ -72,6 +92,10 @@ type Authn interface {
 	// Retrieve retrieves data for the Key identified by the provided
 	// ID, that is issued by the user identified by the provided key.
 	RetrieveKey(ctx context.Context, token, id string) (Key, error)
+
+	// RetrieveKeys retrieves data for the Keys that are
+	// issued by the user identified by the provided key.
+	RetrieveKeys(ctx context.Context, token string, pm PageMetadata) (KeyPage, error)
 
 	// Identify validates token token. If token is valid, content
 	// is returned. If token is invalid, or invocation failed for some
@@ -152,7 +176,16 @@ func (svc service) RetrieveKey(ctx context.Context, token, id string) (Key, erro
 		return Key{}, errors.Wrap(errRetrieve, err)
 	}
 
-	return svc.keys.Retrieve(ctx, issuerID, id)
+	return svc.keys.RetrieveByID(ctx, issuerID, id)
+}
+
+func (svc service) RetrieveKeys(ctx context.Context, token string, pm PageMetadata) (KeyPage, error) {
+	issuerID, _, err := svc.login(token)
+	if err != nil {
+		return KeyPage{}, errors.Wrap(errRetrieve, err)
+	}
+
+	return svc.keys.RetrieveAll(ctx, issuerID, pm)
 }
 
 func (svc service) Identify(ctx context.Context, token string) (Identity, error) {
@@ -169,7 +202,7 @@ func (svc service) Identify(ctx context.Context, token string) (Identity, error)
 	case RecoveryKey, UserKey, EmailVerificationKey:
 		return Identity{ID: key.IssuerID, Email: key.Subject}, nil
 	case APIKey:
-		_, err := svc.keys.Retrieve(context.TODO(), key.IssuerID, key.ID)
+		_, err := svc.keys.RetrieveByID(context.TODO(), key.IssuerID, key.ID)
 		if err != nil {
 			return Identity{}, ErrUnauthorizedAccess
 		}

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -225,6 +225,66 @@ func TestRetrieve(t *testing.T) {
 	}
 }
 
+func TestRetrieveAll(t *testing.T) {
+	svc := newService()
+	_, secret, err := svc.Issue(context.Background(), "", auth.Key{Type: auth.UserKey, IssuedAt: time.Now(), IssuerID: id, Subject: email})
+	assert.Nil(t, err, fmt.Sprintf("Issuing login key expected to succeed: %s", err))
+
+	n := uint64(100)
+	for i := uint64(0); i < n; i++ {
+		key := auth.Key{
+			ID:       "id",
+			Type:     auth.APIKey,
+			IssuerID: id,
+			Subject:  fmt.Sprintf("email-%d@mail.com", i),
+			IssuedAt: time.Now(),
+		}
+		_, _, err := svc.Issue(context.Background(), secret, key)
+		assert.Nil(t, err, fmt.Sprintf("Issuing user's key expected to succeed: %s", err))
+	}
+
+	cases := map[string]struct {
+		token string
+		size  uint64
+		pm    auth.PageMetadata
+		err   error
+	}{
+		"list all keys": {
+			token: secret,
+			pm: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  n,
+			},
+			size: n,
+			err:  nil,
+		},
+		"list all keys with offset": {
+			token: secret,
+			pm: auth.PageMetadata{
+				Offset: 50,
+				Limit:  n,
+				Total:  n,
+			},
+			size: 50,
+			err:  nil,
+		},
+		"list all keys with wrong token": {
+			token: "wrongToken",
+			size:  0,
+			err:   auth.ErrUnauthorizedAccess,
+		},
+	}
+
+	for desc, tc := range cases {
+		page, err := svc.RetrieveKeys(context.Background(), tc.token, tc.pm)
+		size := uint64(len(page.Keys))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected %d got %d\n", desc, tc.size, size))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
+	}
+
+}
+
 func TestIdentify(t *testing.T) {
 	svc := newService()
 

--- a/auth/tracing/keys.go
+++ b/auth/tracing/keys.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	saveOp     = "save"
-	retrieveOp = "retrieve_by_id"
-	revokeOp   = "remove"
+	saveOp        = "save"
+	retrieveOp    = "retrieve_by_id"
+	retrieveAllOp = "retrieve_all"
+	revokeOp      = "remove"
 )
 
 var _ auth.KeyRepository = (*keyRepositoryMiddleware)(nil)
@@ -36,7 +37,6 @@ func New(repo auth.KeyRepository, tracer opentracing.Tracer) auth.KeyRepository 
 	}
 }
 
-
 func (krm keyRepositoryMiddleware) Save(ctx context.Context, key auth.Key) (string, error) {
 	span := createSpan(ctx, krm.tracer, saveOp)
 	defer span.Finish()
@@ -45,12 +45,20 @@ func (krm keyRepositoryMiddleware) Save(ctx context.Context, key auth.Key) (stri
 	return krm.repo.Save(ctx, key)
 }
 
-func (krm keyRepositoryMiddleware) Retrieve(ctx context.Context, owner, id string) (auth.Key, error) {
+func (krm keyRepositoryMiddleware) RetrieveByID(ctx context.Context, owner, id string) (auth.Key, error) {
 	span := createSpan(ctx, krm.tracer, retrieveOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return krm.repo.Retrieve(ctx, owner, id)
+	return krm.repo.RetrieveByID(ctx, owner, id)
+}
+
+func (krm keyRepositoryMiddleware) RetrieveAll(ctx context.Context, owner string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	span := createSpan(ctx, krm.tracer, retrieveAllOp)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return krm.repo.RetrieveAll(ctx, owner, pm)
 }
 
 func (krm keyRepositoryMiddleware) Remove(ctx context.Context, owner, id string) error {

--- a/internal/httputil/token.go
+++ b/internal/httputil/token.go
@@ -5,22 +5,11 @@ package httputil
 
 import (
 	"net/http"
-	"strings"
 )
 
-// BearerPrefix represents the token prefix for Bearer authentication scheme.
-const BearerPrefix = "Bearer "
-
-// ThingPrefix represents the key prefix for Thing authentication scheme.
-const ThingPrefix = "Thing "
-
-// ExtractBearerToken returns value of the bearer token. If there is no bearer token - an empty value is returned.
+// ExtractBearerToken returns value of the token.
 func ExtractBearerToken(r *http.Request) string {
 	token := r.Header.Get("Authorization")
 
-	if !strings.HasPrefix(token, BearerPrefix) {
-		return ""
-	}
-
-	return strings.TrimPrefix(token, BearerPrefix)
+	return token
 }

--- a/internal/httputil/token.go
+++ b/internal/httputil/token.go
@@ -1,0 +1,26 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package httputil
+
+import (
+	"net/http"
+	"strings"
+)
+
+// BearerPrefix represents the token prefix for Bearer authentication scheme.
+const BearerPrefix = "Bearer "
+
+// ThingPrefix represents the key prefix for Thing authentication scheme.
+const ThingPrefix = "Thing "
+
+// ExtractBearerToken returns value of the bearer token. If there is no bearer token - an empty value is returned.
+func ExtractBearerToken(r *http.Request) string {
+	token := r.Header.Get("Authorization")
+
+	if !strings.HasPrefix(token, BearerPrefix) {
+		return ""
+	}
+
+	return strings.TrimPrefix(token, BearerPrefix)
+}


### PR DESCRIPTION
This PR migrates the changes from https://github.com/mainflux/mainflux/pull/1703 to this version. It implements the GET API keys endpoint that will be used by the web application to list user API key information
